### PR TITLE
Allow commands to abort pipeline execution

### DIFF
--- a/cog/response.py
+++ b/cog/response.py
@@ -6,6 +6,10 @@ class Response(object):
         self.template_ = None
         self.content_ = None
         self.message_ = None
+        self.aborted_ = False
+
+    def abort(self):
+        self.aborted_ = True
 
     def string(self, message):
         self.message_ = message
@@ -17,12 +21,15 @@ class Response(object):
         return self
 
     def send(self):
+        if self.aborted_:
+            self.write_("COGCMD_ACTION: abort")
         if self.template_ is not None:
             self.write_("COG_TEMPLATE: %s" % (self.template_))
         if self.content_ is not None:
             self.write_json_()
         else:
-            self.write_string_()
+            if self.message_ is not None:
+                self.write_string_()
 
     def write_string_(self):
         self.write_(json.dumps(self.message_))

--- a/setup.py
+++ b/setup.py
@@ -3,13 +3,13 @@ from distutils.core import setup
 
 setup (
     name = "pycog3",
-    version = "0.1.26",
+    version = "0.1.27",
     scripts = ["bin/cog-command"],
     description = "Command library for the Cog ChatOps platform for Python3",
     author = "Kevin Smith",
     author_email = "kevin@operable.io",
     url = "https://github.com/cog-bundles/pycog3",
-    download_url = "https://github.com/cog-bundles/pycog3/tarball/0.1.25",
+    download_url = "https://github.com/cog-bundles/pycog3/tarball/0.1.27",
     packages = ["cog"],
     requires = ["requests (>=2.10)", "PyYAML (>=3.11)"],
     keywords = ["bot", "devops", "chatops", "automation"],


### PR DESCRIPTION
Implements Python command-facing API for the design described in [#691](https://github.com/operable/cog/issues/691).

Fixes [#691](https://github.com/operable/cog/issues/691)
